### PR TITLE
Yandex Music classic design fix

### DIFF
--- a/src/connectors/yandex-music.js
+++ b/src/connectors/yandex-music.js
@@ -1,0 +1,142 @@
+"use strict";
+(() => {
+  // src/connectors/yandex-music.ts
+  (() => {
+    setupConnector();
+    function setupConnector() {
+      if (isOldPlayer()) {
+        setupOldConnector();
+      } else {
+        setupNewConnector();
+      }
+    }
+    function isOldPlayer() {
+      return window.externalAPI !== void 0;
+    }
+    
+    function setupNewConnector() {
+
+      const observer = new MutationObserver(() => {
+          const el = document.querySelector('.track.track_type_player');
+          if (el) {
+              // catched, initializing connector
+              observer.disconnect();
+              Connector.playerSelector = '.track.track_type_player';
+          }
+      });
+      
+      
+      const btn = document.querySelector(".player-controls__btn_play");
+        if (btn) {
+          const observer = new MutationObserver(() => {
+            Connector.onStateChanged();
+          });
+          observer.observe(btn, { attributes: true, attributeFilter: ["class"] });
+        } else {
+        }
+
+      // watch on changes in DOM to Connector.onStateChanged()
+      const trackObserver = new MutationObserver(() => {
+        Connector.onStateChanged();
+      });
+
+      const trackNode = document.querySelector('.player-controls__track-container');
+      if (trackNode) {
+        trackObserver.observe(trackNode, { childList: true, subtree: true });
+      }
+
+      observer.observe(document.body, { childList: true, subtree: true });
+      Connector.trackSelector = ".track__title";
+      Connector.artistSelector = ".d-artists.d-artists__expanded";
+      // Connector.trackArtSelector = ".entity-cover__image";
+      Connector.getTrackArt = () => {
+        const container = document.querySelector('.player-controls__track-container');
+        if (!container) {
+          return null;
+        }
+
+        const images = container.querySelectorAll('img');
+
+        for (const img of images) {
+          const src = img.getAttribute('src');
+          if (src && src.includes('50x50')) {
+            const absoluteUrl = new URL(src, window.location.origin).toString();
+
+            const highResUrl = absoluteUrl.replace('50x50', '800x800');
+            return highResUrl;
+          }
+        }
+
+        return null;
+      };
+
+      Connector.getAlbum = () => {
+        const albumLink = document.querySelector('a[title^="\u0418\u0437 \u0430\u043B\u044C\u0431\u043E\u043C\u0430"]');
+        if (!albumLink) return null;
+        const match = albumLink.title.match(/^Из альбома «(.+)»$/);
+        return match ? match[1] : null;
+      };
+      Connector.getCurrentTime = () => {
+        const el = document.querySelector(".progress__bar.progress__text");
+        return el ? parseFloat(el.getAttribute("data-played-time") || "0") : null;
+      };
+      Connector.getDuration = () => {
+        const el = document.querySelector(".progress__bar.progress__text");
+        return el ? parseFloat(el.getAttribute("data-duration") || "0") : null;
+      };
+      
+      Connector.isPlaying = () => {
+        const btn = document.querySelector(".player-controls__btn_play");
+        if (!btn) {
+          return false;
+        }
+        return btn.classList.contains("player-controls__btn_pause");
+      };
+
+
+
+      // Don't work now. CUTTED OUT
+      // Connector.loveButtonSelector = [
+      //   ".bar__content button" 
+      // ];
+
+      // Connector.isLoved = () => {
+      //   const buttons = document.querySelectorAll(Connector.loveButtonSelector.join(", "));
+      //   for (const btn of buttons) {
+      //     const icon = btn.querySelector("div.d-icon");
+      //     if (!icon) continue;
+      //  
+      //     if (icon.classList.contains("d-icon_heart-full")) {
+      //       return true;
+      //     }
+      //    
+      //     if (icon.classList.contains("d-icon_heart")) {
+      //       return false;
+      //     }
+      //     console.log(isLoved())
+      //   }
+      //   console.log(isLoved())
+      //   return null; 
+      // };
+    }
+
+    function setupOldConnector() {
+      let trackInfo = {};
+      let isPlaying = false;
+      Connector.isPlaying = () => isPlaying;
+      Connector.getTrackInfo = () => trackInfo;
+      Connector.onScriptEvent = (e) => {
+        switch (e.data.type) {
+          case "YANDEX_MUSIC_STATE":
+            trackInfo = e.data.trackInfo;
+            isPlaying = e.data.isPlaying;
+            Connector.onStateChanged();
+            break;
+          default:
+            break;
+        }
+      };
+      Connector.injectScript("connectors/yandex-music-dom-inject.js");
+    }
+  })();
+})();

--- a/src/connectors/yandex-music.ts
+++ b/src/connectors/yandex-music.ts
@@ -1,88 +1,136 @@
-export {};
-
 setupConnector();
-
 function setupConnector() {
-	if (isOldPlayer()) {
-		setupOldConnector();
-	} else {
-		setupNewConnector();
-	}
+  if (isOldPlayer()) {
+    setupOldConnector();
+  } else {
+    setupNewConnector();
+  }
 }
-
 function isOldPlayer() {
-	return (
-		(window as unknown as { externalAPI: unknown }).externalAPI !==
-		undefined
-	);
+  return window.externalAPI !== void 0;
 }
 
 function setupNewConnector() {
-	// Player
-	Connector.playerSelector = 'section[class*=PlayerBar_root__]';
 
-	Connector.pauseButtonSelector = [
-		'button[aria-label=Pause]',
-		'button[aria-label=Пауза]',
-		'button[aria-label=Pauza]',
-		'button[aria-label=Үзіліс]',
-	];
+  const observer = new MutationObserver(() => {
+      const el = document.querySelector('.track.track_type_player');
+      if (el) {
+          // catched, initializing connector
+          observer.disconnect();
+          Connector.playerSelector = '.track.track_type_player';
+      }
+  });
+  
+  
+  const btn = document.querySelector(".player-controls__btn_play");
+    if (btn) {
+      const observer = new MutationObserver(() => {
+        Connector.onStateChanged();
+      });
+      observer.observe(btn, { attributes: true, attributeFilter: ["class"] });
+    } else {
+    }
 
-	// Track info
-	Connector.trackSelector = `${Connector.playerSelector} span[class*=Meta_title__]`;
+  // watch on changes in DOM to Connector.onStateChanged()
+  const trackObserver = new MutationObserver(() => {
+    Connector.onStateChanged();
+  });
 
-	Connector.artistSelector = `${Connector.playerSelector} span[class*=Meta_artistCaption__]`;
+  const trackNode = document.querySelector('.player-controls__track-container');
+  if (trackNode) {
+    trackObserver.observe(trackNode, { childList: true, subtree: true });
+  }
 
-	Connector.trackArtSelector = [
-		'section img[class*=PlayerBarDesktop_cover__]',
-		'section img[class*=PlayerBarMobile_cover__]',
-	];
+  observer.observe(document.body, { childList: true, subtree: true });
+  Connector.trackSelector = ".track__title";
+  Connector.artistSelector = ".d-artists.d-artists__expanded";
+  // Connector.trackArtSelector = ".entity-cover__image";
+  Connector.getTrackArt = () => {
+    const container = document.querySelector('.player-controls__track-container');
+    if (!container) {
+      return null;
+    }
 
-	// Duration
-	Connector.currentTimeSelector =
-		'section span[class*=Timecode_root_start__]';
-	Connector.durationSelector = 'section span[class*=Timecode_root_end__]';
+    const images = container.querySelectorAll('img');
 
-	// Likes
-	Connector.loveButtonSelector = [
-		'div[class*=PlayerBarDesktop_infoButtons__] button',
-		'div[class*=PlayerBarMobile_infoButtons__] button',
-	];
+    for (const img of images) {
+      const src = img.getAttribute('src');
+      if (src && src.includes('50x50')) {
+        const absoluteUrl = new URL(src, window.location.origin).toString();
 
-	Connector.isLoved = () => {
-		const loved = Util.getAttrFromSelectors(
-			Connector.loveButtonSelector,
-			'aria-pressed',
-		);
+        const highResUrl = absoluteUrl.replace('50x50', '800x800');
+        return highResUrl;
+      }
+    }
 
-		if (loved === null) {
-			return null;
-		}
+    return null;
+  };
 
-		return loved === 'true';
-	};
+  Connector.getAlbum = () => {
+    const albumLink = document.querySelector('a[title^="\u0418\u0437 \u0430\u043B\u044C\u0431\u043E\u043C\u0430"]');
+    if (!albumLink) return null;
+    const match = albumLink.title.match(/^Из альбома «(.+)»$/);
+    return match ? match[1] : null;
+  };
+  Connector.getCurrentTime = () => {
+    const el = document.querySelector(".progress__bar.progress__text");
+    return el ? parseFloat(el.getAttribute("data-played-time") || "0") : null;
+  };
+  Connector.getDuration = () => {
+    const el = document.querySelector(".progress__bar.progress__text");
+    return el ? parseFloat(el.getAttribute("data-duration") || "0") : null;
+  };
+  
+  Connector.isPlaying = () => {
+    const btn = document.querySelector(".player-controls__btn_play");
+    if (!btn) {
+      return false;
+    }
+    return btn.classList.contains("player-controls__btn_pause");
+  };
+
+
+
+  // Don't work now. CUTTED OUT
+  // Connector.loveButtonSelector = [
+  //   ".bar__content button" 
+  // ];
+
+  // Connector.isLoved = () => {
+  //   const buttons = document.querySelectorAll(Connector.loveButtonSelector.join(", "));
+  //   for (const btn of buttons) {
+  //     const icon = btn.querySelector("div.d-icon");
+  //     if (!icon) continue;
+  //  
+  //     if (icon.classList.contains("d-icon_heart-full")) {
+  //       return true;
+  //     }
+  //    
+  //     if (icon.classList.contains("d-icon_heart")) {
+  //       return false;
+  //     }
+  //     console.log(isLoved())
+  //   }
+  //   console.log(isLoved())
+  //   return null; 
+  // };
 }
 
 function setupOldConnector() {
-	let trackInfo = {};
-	let isPlaying = false;
-
-	Connector.isPlaying = () => isPlaying;
-
-	Connector.getTrackInfo = () => trackInfo;
-
-	Connector.onScriptEvent = (e) => {
-		switch (e.data.type) {
-			case 'YANDEX_MUSIC_STATE':
-				trackInfo = e.data.trackInfo as object;
-				isPlaying = e.data.isPlaying as boolean;
-
-				Connector.onStateChanged();
-				break;
-			default:
-				break;
-		}
-	};
-
-	Connector.injectScript('connectors/yandex-music-dom-inject.js');
+  let trackInfo = {};
+  let isPlaying = false;
+  Connector.isPlaying = () => isPlaying;
+  Connector.getTrackInfo = () => trackInfo;
+  Connector.onScriptEvent = (e) => {
+    switch (e.data.type) {
+      case "YANDEX_MUSIC_STATE":
+        trackInfo = e.data.trackInfo;
+        isPlaying = e.data.isPlaying;
+        Connector.onStateChanged();
+        break;
+      default:
+        break;
+    }
+  };
+  Connector.injectScript("connectors/yandex-music-dom-inject.js");
 }


### PR DESCRIPTION
This update rewrites the Yandex Music connector to support the old design of the player. The connector is now more robust and consistent in tracking playback and track info. The logic has been updated to better handle DOM structure and ensure reliable detection of state changes.

— Waits for the track container to appear before initializing — Sets up a MutationObserver to watch for changes in the play/pause button’s class list — Adds another MutationObserver to track DOM changes related to track info updates — Updates selectors for track title and artist name — Retrieves album art in higher resolution by modifying the image URL from 50x50 to 800x800 — Extracts album name from the "Из альбома" link using its title attribute — Reworks isPlaying logic to correctly detect the playing state by checking for the player-controls__btn_pause class — Removes the isLoved feature due to unreliable DOM structure and inconsistent button behavior — Acknowledges occasional “Extension context invalidated” errors during extension reload, which do not affect actual functionality — Targets only the classic Yandex Music design — support for the new layout would require additional time and likely a separate connector

P.S. There are two known issues:
— Occasionally, an “Extension context invalidated” error appears in the console when reloading the extension. This is a benign issue related to how Chrome handles reinitialization and does not affect functionality.

— Another issue is an uncaught promise error: “A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received.” This appears to be related to the core logic of the extension and is not caused by the connector code itself.

**Additional context**
![image](https://github.com/user-attachments/assets/37b60981-912a-4cc5-bf0e-6cce2d2735c4) 
![image](https://github.com/user-attachments/assets/8a4eb530-e781-4154-9f47-484144b90f60) 
![image](https://github.com/user-attachments/assets/497a0388-0ac2-45a5-95ac-2c466b87e334)
